### PR TITLE
Revealed information about the bone that was interacted with in ModelDamageEvent and ModelInteractEvent

### DIFF
--- a/src/main/java/net/worldseed/multipart/ModelEngine.java
+++ b/src/main/java/net/worldseed/multipart/ModelEngine.java
@@ -56,14 +56,14 @@ public class ModelEngine {
     });
     private static final EventListener<PlayerEntityInteractEvent> playerInteractListener = EventListener.of(PlayerEntityInteractEvent.class, event -> {
         if (event.getTarget() instanceof BoneEntity bone) {
-            ModelInteractEvent modelInteractEvent = new ModelInteractEvent(bone.getModel(), event.getPlayer());
+            ModelInteractEvent modelInteractEvent = new ModelInteractEvent(bone.getModel(), event.getPlayer(), bone);
             EventDispatcher.call(modelInteractEvent);
         }
     });
     private static final EventListener<EntityDamageEvent> entityDamageListener = EventListener.of(EntityDamageEvent.class, event -> {
         if (event.getEntity() instanceof BoneEntity bone) {
             event.setCancelled(true);
-            ModelDamageEvent modelDamageEvent = new ModelDamageEvent(bone.getModel(), event);
+            ModelDamageEvent modelDamageEvent = new ModelDamageEvent(bone.getModel(), event, bone);
             MinecraftServer.getGlobalEventHandler().call(modelDamageEvent);
         }
     });

--- a/src/main/java/net/worldseed/multipart/events/ModelDamageEvent.java
+++ b/src/main/java/net/worldseed/multipart/events/ModelDamageEvent.java
@@ -5,11 +5,13 @@ import net.minestom.server.event.entity.EntityDamageEvent;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.sound.SoundEvent;
 import net.worldseed.multipart.GenericModel;
+import net.worldseed.multipart.model_bones.BoneEntity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ModelDamageEvent implements ModelEvent, CancellableEvent {
     private final GenericModel model;
+    private final BoneEntity hitBone;
     private final Damage damage;
     private SoundEvent sound;
 
@@ -17,15 +19,15 @@ public class ModelDamageEvent implements ModelEvent, CancellableEvent {
 
     private boolean cancelled;
 
-    public ModelDamageEvent(GenericModel model, @NotNull Damage damage,
-                            @Nullable SoundEvent sound) {
-        this.model = model;
-        this.damage = damage;
-        this.sound = sound;
-    }
-
     public ModelDamageEvent(GenericModel model, EntityDamageEvent event) {
-        this(model, event.getDamage(), event.getSound());
+        this(model, event, null);
+    }
+    
+    public ModelDamageEvent(GenericModel model, EntityDamageEvent event, @Nullable BoneEntity hitBone) {
+        this.model = model;
+        this.hitBone = hitbone;
+        this.damage = event.getDamage();
+        this.sound = event.getSound();
         this.animation = event.shouldAnimate();
     }
 
@@ -74,6 +76,15 @@ public class ModelDamageEvent implements ModelEvent, CancellableEvent {
      */
     public void setAnimation(boolean animation) {
         this.animation = animation;
+    }
+
+    /**
+     * Gets the hitbox bone that has been hit.
+     *
+     * @return the hitbox bone that has been hit, or null if it was an EmotePlayer
+     */
+    public @Nullable BoneEntity getBone() {
+        return hitBone;
     }
 
     @Override

--- a/src/main/java/net/worldseed/multipart/events/ModelInteractEvent.java
+++ b/src/main/java/net/worldseed/multipart/events/ModelInteractEvent.java
@@ -1,23 +1,31 @@
 package net.worldseed.multipart.events;
 
-import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.Player;
+import net.worldseed.multipart.model_bones.BoneEntity;
 import net.minestom.server.event.player.PlayerEntityInteractEvent;
 import net.worldseed.gestures.EmoteModel;
 import net.worldseed.multipart.GenericModel;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ModelInteractEvent implements ModelEvent {
     private final GenericModel model;
-    private final Entity interactor;
+    private final Player interactor;
+    private final BoneEntity interactedBone;
+    private final Player.Hand hand;
 
-    public ModelInteractEvent(@NotNull GenericModel model, Entity interactor) {
+    public ModelInteractEvent(@NotNull GenericModel model, PlayerEntityInteractEvent event, BoneEntity interactedBone) {
         this.model = model;
-        this.interactor = interactor;
+        this.hand = event.getHand();
+        this.interactor = event.getPlayer();
+        this.interactedBone = interactedBone;
     }
 
-    public ModelInteractEvent(EmoteModel model, PlayerEntityInteractEvent event) {
+    public ModelInteractEvent(@NotNull EmoteModel model, PlayerEntityInteractEvent event) {
         this.model = model;
+        this.hand = event.getHand();
         this.interactor = event.getPlayer();
+        this.interactedBone = null;
     }
 
     @Override
@@ -25,8 +33,16 @@ public class ModelInteractEvent implements ModelEvent {
         return model;
     }
 
-    public @NotNull Entity getInteracted() {
+    public @NotNull Player.Hand getHand() {
+        return hand;
+    }
+
+    public @NotNull Player getInteracted() { // This should probably be getInteractor() or getPlayer() but I left this untouched so code doesn't break
         return interactor;
+    }
+    
+    public @Nullable BoneEntity getBone() {
+        return interactedBone;
     }
 }
 

--- a/src/main/java/net/worldseed/multipart/events/ModelInteractEvent.java
+++ b/src/main/java/net/worldseed/multipart/events/ModelInteractEvent.java
@@ -14,18 +14,15 @@ public class ModelInteractEvent implements ModelEvent {
     private final BoneEntity interactedBone;
     private final Player.Hand hand;
 
-    public ModelInteractEvent(@NotNull GenericModel model, PlayerEntityInteractEvent event, BoneEntity interactedBone) {
+    public ModelInteractEvent(@NotNull EmoteModel model, PlayerEntityInteractEvent event) {
+        this(model, event, null);
+    }
+    
+    public ModelInteractEvent(@NotNull GenericModel model, PlayerEntityInteractEvent event, @Nullable BoneEntity interactedBone) {
         this.model = model;
         this.hand = event.getHand();
         this.interactor = event.getPlayer();
         this.interactedBone = interactedBone;
-    }
-
-    public ModelInteractEvent(@NotNull EmoteModel model, PlayerEntityInteractEvent event) {
-        this.model = model;
-        this.hand = event.getHand();
-        this.interactor = event.getPlayer();
-        this.interactedBone = null;
     }
 
     @Override

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
@@ -62,7 +62,7 @@ public class ModelBoneHitbox extends ModelBoneImpl implements HitboxBone {
                     }
                 };
 
-                this.stand.setTag(WSEE, name);
+                this.stand.setTag(WSEE, "hitbox");
                 this.offset = newOffset;
 
                 InteractionMeta meta = (InteractionMeta) this.stand.getEntityMeta();

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
@@ -62,7 +62,7 @@ public class ModelBoneHitbox extends ModelBoneImpl implements HitboxBone {
                     }
                 };
 
-                this.stand.setTag(WSEE, "hitbox");
+                this.stand.setTag(WSEE, name);
                 this.offset = newOffset;
 
                 InteractionMeta meta = (InteractionMeta) this.stand.getEntityMeta();


### PR DESCRIPTION
I added the damaged or interacted hitbox bone to ModelDamageEvent and ModelInteractEvent and replaced "hitbox" with the hitbox's name in its Tag. 

The goal of this pull request is to be able to know which bone was hit or interacted with, and compare it with the names you gave your hitbox bones in blockbench.