### PR TITLE
Added animation merging

### DIFF
--- a/src/main/java/net/worldseed/multipart/animations/AnimationHandler.java
+++ b/src/main/java/net/worldseed/multipart/animations/AnimationHandler.java
@@ -3,7 +3,6 @@ package net.worldseed.multipart.animations;
 import com.google.gson.JsonElement;
 
 import java.util.Map;
-import java.util.function.Consumer;
 
 public interface AnimationHandler {
     void registerAnimation(String name, JsonElement animation, int priority);
@@ -26,6 +25,17 @@ public interface AnimationHandler {
      */
     void stopRepeat(String animation) throws IllegalArgumentException;
 
+
+
+    /**
+     * Play an animation once
+     *
+     * @param animation name of animation to play
+     * @param override If true (default), fully overrides repeating background animations. If false, overrides only bones used in new animation.
+     * @param cb       callback to call when animation is finished
+     */
+    void playOnce(String animation, boolean override, Runnable cb) throws IllegalArgumentException;
+
     /**
      * Play an animation once
      *
@@ -34,7 +44,7 @@ public interface AnimationHandler {
      */
     void playOnce(String animation, Runnable cb) throws IllegalArgumentException;
 
-    void playOnce(String animation, AnimationHandlerImpl.AnimationDirection direction, Runnable cb) throws IllegalArgumentException;
+    void playOnce(String animation, AnimationHandlerImpl.AnimationDirection direction, boolean override, Runnable cb) throws IllegalArgumentException;
 
     /**
      * Destroy the animation handler

--- a/src/main/java/net/worldseed/multipart/animations/BoneAnimation.java
+++ b/src/main/java/net/worldseed/multipart/animations/BoneAnimation.java
@@ -6,6 +6,8 @@ import net.worldseed.multipart.ModelLoader;
 public interface BoneAnimation {
     String name();
 
+    String boneName();
+
     ModelLoader.AnimationType getType();
 
     Point getTransformAtTime(int time);
@@ -21,4 +23,6 @@ public interface BoneAnimation {
     void play();
 
     void tick();
+    void resume(short tick);
+    short getTick();
 }

--- a/src/main/java/net/worldseed/multipart/animations/BoneAnimationImpl.java
+++ b/src/main/java/net/worldseed/multipart/animations/BoneAnimationImpl.java
@@ -20,6 +20,7 @@ public class BoneAnimationImpl implements BoneAnimation {
     private final FrameProvider frameProvider;
     private final int length;
     private final String name;
+    private final String boneName;
     private boolean playing = false;
     private short tick = 0;
     private AnimationHandlerImpl.AnimationDirection direction = AnimationHandlerImpl.AnimationDirection.FORWARD;
@@ -28,6 +29,7 @@ public class BoneAnimationImpl implements BoneAnimation {
         this.type = animationType;
         this.length = (int) (length * 20);
         this.name = animationName;
+        this.boneName = boneName;
 
         FrameProvider found;
         if (this.type == ModelLoader.AnimationType.ROTATION) {
@@ -180,8 +182,21 @@ public class BoneAnimationImpl implements BoneAnimation {
         this.playing = true;
     }
 
+    public void resume(short tick) {
+        this.tick = tick;
+        this.playing = true;
+    }
+
     public String name() {
         return name;
+    }
+
+    public String boneName() {
+        return boneName;
+    }
+
+    public short getTick() {
+        return tick;
     }
 
     record PointInterpolation(MQLPoint p, String lerp) {

--- a/src/main/java/net/worldseed/multipart/animations/ModelAnimation.java
+++ b/src/main/java/net/worldseed/multipart/animations/ModelAnimation.java
@@ -1,5 +1,7 @@
 package net.worldseed.multipart.animations;
 
+import java.util.Set;
+
 public interface ModelAnimation {
     int priority();
 
@@ -8,12 +10,16 @@ public interface ModelAnimation {
     String name();
 
     AnimationHandler.AnimationDirection direction();
+    Set<String> getAnimatedBones();
 
     void setDirection(AnimationHandler.AnimationDirection direction);
 
     void stop();
 
-    void play();
+    void stop(Set<String> animatedBones);
+
+    void play(boolean resume);
 
     void tick();
+
 }

--- a/src/main/java/net/worldseed/multipart/animations/ModelAnimationClassic.java
+++ b/src/main/java/net/worldseed/multipart/animations/ModelAnimationClassic.java
@@ -1,6 +1,7 @@
 package net.worldseed.multipart.animations;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public class ModelAnimationClassic implements ModelAnimation {
@@ -9,11 +10,13 @@ public class ModelAnimationClassic implements ModelAnimation {
     private final int animationTime;
     private AnimationHandler.AnimationDirection direction;
     private final Set<BoneAnimation> boneAnimations;
+    private final Set<String> animatedBones;
 
-    public ModelAnimationClassic(String name, int animationTime, int priority, HashSet<BoneAnimation> animationSet) {
+    public ModelAnimationClassic(String name, int animationTime, int priority, HashSet<BoneAnimation> animationSet, HashSet<String> animatedBones) {
         this.direction = AnimationHandler.AnimationDirection.PAUSE;
         this.animationTime = animationTime;
         this.boneAnimations = animationSet;
+        this.animatedBones = animatedBones;
         this.name = name;
         this.priority = priority;
     }
@@ -50,12 +53,32 @@ public class ModelAnimationClassic implements ModelAnimation {
     }
 
     @Override
-    public void play() {
+    public void stop(Set<String> animatedBones) { //Only stop bones that are in the new playOnce animation
+        boneAnimations.forEach(boneAnimation -> {
+            if (animatedBones.contains(boneAnimation.boneName())) {
+                boneAnimation.stop();
+            }
+        });
+    }
+
+    @Override
+    public void play(boolean resume) {
+        if (resume) {
+            Optional<Short> tick = boneAnimations.stream().filter(BoneAnimation::isPlaying).findFirst().map(BoneAnimation::getTick);
+            if (tick.isPresent()) {
+                boneAnimations.forEach(boneAnimation -> boneAnimation.resume(tick.get()));
+                return;
+            }
+        }
         boneAnimations.forEach(BoneAnimation::play);
     }
 
     @Override
     public void tick() {
         boneAnimations.forEach(BoneAnimation::tick);
+    }
+
+    public Set<String> getAnimatedBones() {
+        return animatedBones;
     }
 }


### PR DESCRIPTION
I added the boolean `override` to the animationHandler.playOnce method and if set to false the background repeating animation will continue playing while only the bones with a configured animation in the new animation will stop in the repeating animation. 

Solving my own issue https://github.com/AtlasEngineCa/WorldSeedEntityEngine/issues/24

I described everything I changed in the descriptions