### PR TITLE
Added an option to rotate a model in the pitch axis

### DIFF
--- a/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
+++ b/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
@@ -50,7 +50,7 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
             });
         }
 
-        switch(this.name) {
+        switch (this.name) {
             case "Head" -> {
                 this.diff = this.pivot.add(0, 0, 0);
             }
@@ -207,6 +207,6 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
     }
 
     @Override
-    public void setGlobalRotation(double rotation) {
+    public void setGlobalRotation(double yaw, double pitch) {
     }
 }

--- a/src/main/java/net/worldseed/multipart/GenericModel.java
+++ b/src/main/java/net/worldseed/multipart/GenericModel.java
@@ -37,6 +37,13 @@ public interface GenericModel extends Viewable, EventHandler<ModelEvent>, Shape 
     Point getPivot();
 
     /**
+     * Get the rotation of the model on the X axis
+     *
+     * @return the pitch
+     */
+    double getPitch();
+
+    /**
      * Get the rotation of the model on the Y axis
      *
      * @return the global rotation
@@ -49,6 +56,14 @@ public interface GenericModel extends Viewable, EventHandler<ModelEvent>, Shape 
      * @param rotation new global rotation
      */
     void setGlobalRotation(double rotation);
+
+    /**
+     * Set the rotation of the model on the Y and X axis
+     *
+     * @param yaw   new global rotation
+     * @param pitch new pitch
+     */
+    void setGlobalRotation(double yaw, double pitch);
 
     /**
      * Get the postion offset for drawing the model
@@ -140,6 +155,8 @@ public interface GenericModel extends Viewable, EventHandler<ModelEvent>, Shape 
     @Nullable BoneEntity generateRoot();
 
     void bindNametag(String name, Entity nametag);
+
     void unbindNametag(String name);
+
     @Nullable Entity getNametag(String name);
 }

--- a/src/main/java/net/worldseed/multipart/GenericModelImpl.java
+++ b/src/main/java/net/worldseed/multipart/GenericModelImpl.java
@@ -53,8 +53,12 @@ public abstract class GenericModelImpl implements GenericModel {
     protected Instance instance;
     private Pos position;
     private double globalRotation;
+    private double pitch;
 
-    protected record ModelBoneInfo(String name, Point pivot, Point rotation, JsonArray cubes, GenericModel model, float scale) {}
+    protected record ModelBoneInfo(String name, Point pivot, Point rotation, JsonArray cubes, GenericModel model,
+                                   float scale) {
+    }
+
     protected final Map<Predicate<String>, Function<ModelBoneInfo, @Nullable ModelBone>> boneSuppliers = new LinkedHashMap<>();
     Function<ModelBoneInfo, ModelBone> defaultBoneSupplier = (info) -> new ModelBonePartDisplay(info.pivot, info.name, info.rotation, info.model, info.scale);
 
@@ -80,11 +84,21 @@ public abstract class GenericModelImpl implements GenericModel {
         return globalRotation;
     }
 
-    public void setGlobalRotation(double rotation) {
-        this.globalRotation = rotation;
+    @Override
+    public double getPitch(){
+        return pitch;
+    }
+
+    public void setGlobalRotation(double yaw) {
+        setGlobalRotation(yaw, 0.0f);
+    }
+
+    public void setGlobalRotation(double yaw, double pitch) {
+        this.globalRotation = yaw;
+        this.pitch = pitch;
 
         this.viewableBones.forEach(part -> {
-            part.setGlobalRotation(rotation);
+            part.setGlobalRotation(yaw, pitch);
         });
     }
 

--- a/src/main/java/net/worldseed/multipart/model_bones/ModelBone.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/ModelBone.java
@@ -81,7 +81,7 @@ public interface ModelBone {
 
     void detachModel(GenericModel model);
 
-    void setGlobalRotation(double rotation);
+    void setGlobalRotation(double yaw, double pitch);
 
     default void teleport(Point position) {}
 

--- a/src/main/java/net/worldseed/multipart/model_bones/display_entity/ModelBonePartDisplay.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/display_entity/ModelBonePartDisplay.java
@@ -137,10 +137,11 @@ public class ModelBonePartDisplay extends ModelBoneImpl implements ModelBoneView
     }
 
     @Override
-    public void setGlobalRotation(double rotation) {
+    public void setGlobalRotation(double yaw, double pitch) {
         if (this.stand != null) {
-            var correctLocation = (180 + this.model.getGlobalRotation() + 360) % 360;
-            this.stand.setView((float) correctLocation, 0);
+            var correctYaw = (180 + yaw + 360) % 360;
+            var correctPitch = (pitch + 360) % 360;
+            this.stand.setView((float) correctYaw, (float) correctPitch);
         }
     }
 

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
@@ -131,7 +131,7 @@ public class ModelBoneHitbox extends ModelBoneImpl implements HitboxBone {
     }
 
     @Override
-    public void setGlobalRotation(double rotation) {
+    public void setGlobalRotation(double yaw, double pitch) {
     }
 
     public void generateStands(JsonArray cubes, Point pivotPos, String name, Point boneRotation, GenericModel genericModel) {

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneNametag.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneNametag.java
@@ -61,7 +61,7 @@ public class ModelBoneNametag extends ModelBoneImpl implements NametagBone {
     }
 
     @Override
-    public void setGlobalRotation(double rotation) {
+    public void setGlobalRotation(double yaw, double pitch) {
     }
 
     @Override

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneSeat.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneSeat.java
@@ -83,7 +83,7 @@ public class ModelBoneSeat extends ModelBoneImpl implements RideableBone {
     }
 
     @Override
-    public void setGlobalRotation(double rotation) {
+    public void setGlobalRotation(double yaw, double pitch) {
 
     }
 

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneVFX.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneVFX.java
@@ -40,7 +40,7 @@ public class ModelBoneVFX extends ModelBoneImpl implements VFXBone {
     }
 
     @Override
-    public void setGlobalRotation(double rotation) {
+    public void setGlobalRotation(double yaw, double pitch) {
 
     }
 


### PR DESCRIPTION
I also tried to make it so a model spawns with the pitch rotation from the `Pos` in `init()`

Because right now it has to do a rotating animation which looks bad because I need a model to spawn with the pitch and yaw from the player but I honestly have no idea how quaternion or euler works.

I would really appreciate if you could add this for me, as it would save me a lot of time trying to figure it out myself