### PR TITLE
Allow generating the pack without needing the server to be initialized.

### DIFF
--- a/src/main/java/net/worldseed/multipart/ModelEngine.java
+++ b/src/main/java/net/worldseed/multipart/ModelEngine.java
@@ -60,20 +60,18 @@ public class ModelEngine {
     private static Path modelPath;
     private static Material modelMaterial = Material.MAGMA_CREAM;
 
-    static {
-        MinecraftServer.getGlobalEventHandler()
-                .addListener(playerListener)
-                .addListener(playerInteractListener)
-                .addListener(entityDamageListener);
-    }
-
     /**
-     * Loads the model from the given path
+     * Loads the model from the given path. Assumes the server is already initialized.
      *
      * @param mappingsData mappings file created by model parser
      * @param modelPath    path of the models
      */
     public static void loadMappings(Reader mappingsData, Path modelPath) {
+        MinecraftServer.getGlobalEventHandler()
+                .addListener(playerListener)
+                .addListener(playerInteractListener)
+                .addListener(entityDamageListener);
+
         JsonObject map = GSON.fromJson(mappingsData, JsonObject.class);
         ModelEngine.modelPath = modelPath;
 

--- a/src/main/java/net/worldseed/resourcepack/PackBuilder.java
+++ b/src/main/java/net/worldseed/resourcepack/PackBuilder.java
@@ -27,7 +27,7 @@ public class PackBuilder {
         return inflated.build();
     }
 
-    public static ConfigJson Generate(Path bbmodel, Path resourcepack, Path modelDataPath) throws Exception {
+    public static ConfigJson generate(Path bbmodel, Path resourcepack, Path modelDataPath) throws Exception {
         Files.createDirectories(resourcepack);
         Files.createDirectories(modelDataPath);
 

--- a/src/test/java/BuildPack.java
+++ b/src/test/java/BuildPack.java
@@ -10,7 +10,7 @@ public class BuildPack {
 
     public static void main(String[] args) throws Exception {
         FileUtils.copyDirectory(BASE_PATH.resolve("resourcepack_template").toFile(), BASE_PATH.resolve("resourcepack").toFile());
-        var config = PackBuilder.Generate(BASE_PATH.resolve("bbmodel"), BASE_PATH.resolve("resourcepack"), MODEL_PATH);
+        var config = PackBuilder.generate(BASE_PATH.resolve("bbmodel"), BASE_PATH.resolve("resourcepack"), MODEL_PATH);
         FileUtils.writeStringToFile(BASE_PATH.resolve("model_mappings.json").toFile(), config.modelMappings(), Charset.defaultCharset());
     }
 }

--- a/src/test/java/Main.java
+++ b/src/test/java/Main.java
@@ -60,7 +60,7 @@ public class Main {
         ModelEngine.setModelMaterial(Material.MAGMA_CREAM);
 
         FileUtils.copyDirectory(BASE_PATH.resolve("resourcepack_template").toFile(), BASE_PATH.resolve("resourcepack").toFile());
-        var config = PackBuilder.Generate(BASE_PATH.resolve("bbmodel"), BASE_PATH.resolve("resourcepack"), MODEL_PATH);
+        var config = PackBuilder.generate(BASE_PATH.resolve("bbmodel"), BASE_PATH.resolve("resourcepack"), MODEL_PATH);
         FileUtils.writeStringToFile(BASE_PATH.resolve("model_mappings.json").toFile(), config.modelMappings(), Charset.defaultCharset());
 
         Reader mappingsData = new InputStreamReader(new FileInputStream(BASE_PATH.resolve("model_mappings.json").toFile()));


### PR DESCRIPTION
The class `ModelEngine` had a static block registering events to the global listener.
This code was being executed even if one was just using `PackBuilder.Generate` without having initialized the server, so I moved it at the beginning of `ModelEngine.loadMappings`.
In my opinion, it would be useful to move this bit of code into a separate function `ModelEngine.setEventNode(eventNode)`, so that the user has to specify the `EventNode`. I also renamed `PackBuilder.Generate` to `PackBuilder.generate`.