### PR TITLE
Display context must be HEAD after 1.21.5 Minecraft update.

### DIFF
--- a/src/main/java/net/worldseed/multipart/model_bones/display_entity/ModelBonePartDisplay.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/display_entity/ModelBonePartDisplay.java
@@ -38,7 +38,7 @@ public class ModelBonePartDisplay extends ModelBoneImpl implements ModelBoneView
             var itemMeta = (ItemDisplayMeta) this.stand.getEntityMeta();
 
             itemMeta.setScale(new Vec(scale, scale, scale));
-            itemMeta.setDisplayContext(ItemDisplayMeta.DisplayContext.THIRDPERSON_LEFT_HAND);
+            itemMeta.setDisplayContext(ItemDisplayMeta.DisplayContext.HEAD);
             itemMeta.setTransformationInterpolationDuration(2);
             itemMeta.setPosRotInterpolationDuration(2);
             itemMeta.setViewRange(1000);


### PR DESCRIPTION
As of 1.21.5, Mojang updated the rendering of ItemDisplay so that "firstperson_lefthand and thirdperson_lefthand transforms are now rendered the same as when held in hand."  This created an issue when rendering models with multiple bones. To fix this, I changed the DisplayContext to HEAD.