### PR TITLE
Use fixed display context instead of HEAD as HEAD uses different offsets

### DIFF
--- a/src/main/java/net/worldseed/multipart/model_bones/display_entity/ModelBonePartDisplay.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/display_entity/ModelBonePartDisplay.java
@@ -38,7 +38,7 @@ public class ModelBonePartDisplay extends ModelBoneImpl implements ModelBoneView
             var itemMeta = (ItemDisplayMeta) this.stand.getEntityMeta();
 
             itemMeta.setScale(new Vec(scale, scale, scale));
-            itemMeta.setDisplayContext(ItemDisplayMeta.DisplayContext.HEAD);
+            itemMeta.setDisplayContext(ItemDisplayMeta.DisplayContext.FIXED);
             itemMeta.setTransformationInterpolationDuration(2);
             itemMeta.setPosRotInterpolationDuration(2);
             itemMeta.setViewRange(1000);

--- a/src/main/java/net/worldseed/resourcepack/multipart/parser/ModelParser.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/parser/ModelParser.java
@@ -84,7 +84,7 @@ public class ModelParser {
         return Json.createObjectBuilder()
                 .add("head", builtHead)
                 .add("thirdperson_righthand", builtArm)
-                .add("thirdperson_lefthand", builtDisplay)
+                .add("fixed", builtDisplay)
                 .build();
     }
 


### PR DESCRIPTION
The PR #54 fixed some issues that were related to how the hand contexts were rendered. However, it now used the offsets for DisplayContext.HEAD which pushed entities into the ground. It also caused issues where bones were completely misaligned in certain models (probably related to rotation).

Here is a custom model before this PR:
<img width="453" height="376" alt="grafik" src="https://github.com/user-attachments/assets/66962053-2f85-474d-aa4a-7422b32083de" />

And here is the same model with the fixes applied:
<img width="2560" height="1369" alt="grafik" src="https://github.com/user-attachments/assets/c5b4df6a-2d21-463e-a387-3150a5110796" />
